### PR TITLE
Removed propertydrawer of DBInfo

### DIFF
--- a/Assets/Scripts/Core/Declaration/Const.cs
+++ b/Assets/Scripts/Core/Declaration/Const.cs
@@ -36,8 +36,6 @@ namespace Core
         public const string ContentObjectName = "Content";
         public const string ContentObjectFieldName = "ContentObject";
 
-        public const string DBInfo_AllFound_FieldName = "AllFound";
-        public const string DBInfo_NotFoundObects_FieldName = "NotFoundObjects";
         #endregion
 
 

--- a/Assets/Scripts/Core/EditorPartial/BaseUI_Editor_Partial.cs
+++ b/Assets/Scripts/Core/EditorPartial/BaseUI_Editor_Partial.cs
@@ -24,6 +24,7 @@ namespace Core
         [SerializeField]
         public DBInfo DBInfo = new();
 
+
         public List<string> AutoAssignUIs()
         {
             FindUI(transform, GetContextFieldsNames());


### PR DESCRIPTION
Note: It is not good for using EditorGUILayout in propertydrawer for  performances.

see: [PropertyDrawers](https://docs.unity3d.com/2021.3/Documentation/Manual/editor-PropertyDrawers.html)